### PR TITLE
Update Node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM portainer/portainer-ce:latest as portainer
-FROM node:18-alpine3.17
+FROM node:22.23.1-alpine3.24
 
 WORKDIR /
 COPY --from=portainer . .


### PR DESCRIPTION
node:18-alpine3.17 produces this error in new versions of portainer
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'http-proxy-middleware@4.2.0',
npm WARN EBADENGINE   required: { node: '^22.15.0 || ^24.0.0 || >=26.0.0' },
npm WARN EBADENGINE   current: { node: 'v18.19.0', npm: '10.2.3' }
npm WARN EBADENGINE }
```
22.23.1-alpine3.24 fixes this